### PR TITLE
Reorder assessment and criteria display

### DIFF
--- a/main.py
+++ b/main.py
@@ -457,12 +457,15 @@ def main():
                     
                     st.markdown(f'<div class="takeaway-box">{takeaway_text}</div>', unsafe_allow_html=True)
 
-                    # Criteria dashboard and assessment box
-                    criteria = article.get('criteria_results', [])
-                    render_criteria_dashboard(criteria)
+                    # Assessment box displayed before criteria details
                     assessment = article.get('assessment', 'N/A')
                     score = article.get('assessment_score', 0)
                     render_assessment_box(assessment, score)
+
+                    # Criteria dashboard in a collapsed expander for compact viewing
+                    criteria = article.get('criteria_results', [])
+                    with st.expander("Criteria Details", expanded=False):
+                        render_criteria_dashboard(criteria)
         elif st.session_state.scan_complete and not st.session_state.current_articles:
             with results_section:
                 st.warning("No articles found. Please try adjusting the time period or check the source sites.")

--- a/main_agent_based.py
+++ b/main_agent_based.py
@@ -261,14 +261,15 @@ def main():
                         for point in key_points:
                             st.markdown(f"• {point}")
 
-                    # Criteria dashboard
-                    criteria = article.get('criteria_results', [])
-                    render_criteria_dashboard(criteria)
-
-                    # Assessment summary
+                    # Assessment summary shown before criteria details
                     assessment = article.get('assessment', 'N/A')
                     score = article.get('assessment_score', 0)
                     render_assessment_box(assessment, score)
+
+                    # Criteria dashboard in a collapsed expander
+                    criteria = article.get('criteria_results', [])
+                    with st.expander("Criteria Details", expanded=False):
+                        render_criteria_dashboard(criteria)
 
     except Exception as e:
         st.error(f"Application error: {str(e)}")


### PR DESCRIPTION
## Summary
- show article assessment before the criteria table
- put criteria inside a collapsed Streamlit expander for easier viewing

## Testing
- `python -m py_compile main.py main_agent_based.py`
