### PR TITLE
Fix dark theme regression

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,6 +2,24 @@
 headless = true
 address = "0.0.0.0"
 port = 5000
+enableCORS = false
+enableXsrfProtection = false
 
 [theme]
-primaryColor = "#7B61FF"
+base = "dark"
+primaryColor = "#9C5CFF"
+backgroundColor = "#0E1525"
+secondaryBackgroundColor = "#1C2333"
+textColor = "#F5F9FC"
+font = "sans serif"
+
+[client]
+toolbarMode = "minimal"
+showSidebarNavigation = true
+
+[browser]
+gatherUsageStats = false
+serverAddress = "0.0.0.0"
+
+[logger]
+level = "info"


### PR DESCRIPTION
## Summary
- restore dark theme settings in `.streamlit/config.toml`

## Testing
- `python -m py_compile main.py`