### PR TITLE
Sort articles by assessment priority

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,7 +2,12 @@ import streamlit as st
 from datetime import datetime, timedelta
 from utils.content_extractor import load_source_sites, find_ai_articles, extract_full_content
 from utils.ai_analyzer import summarize_article
-from utils.report_tools import generate_pdf_report, generate_csv_report, generate_excel_report
+from utils.report_tools import (
+    generate_pdf_report,
+    generate_csv_report,
+    generate_excel_report,
+    sort_by_assessment_and_score,
+)
 from utils.simple_particles import add_simple_particles
 from agents.evaluation_agent import EvaluationAgent
 import pandas as pd
@@ -359,7 +364,9 @@ def main():
                 st.session_state.scan_complete = True
 
                 # Store the current articles for persistent access
-                st.session_state.current_articles = st.session_state.articles.copy()
+                st.session_state.current_articles = sort_by_assessment_and_score(
+                    st.session_state.articles.copy()
+                )
 
                 # Generate reports and store them in session state
                 if st.session_state.articles:

--- a/main_agent_based.py
+++ b/main_agent_based.py
@@ -5,6 +5,7 @@ import logging
 # Import the new agent-based components
 from agents.orchestrator import Orchestrator
 from utils.simple_particles import add_simple_particles
+from utils.report_tools import sort_by_assessment_and_score
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -213,7 +214,9 @@ def main():
                         st.session_state.excel_data = result['reports'].get('excel')
                         st.session_state.processing_time = result['execution_time']
                         st.session_state.scan_complete = True
-                        st.session_state.current_articles = st.session_state.selected_articles.copy()
+                        st.session_state.current_articles = sort_by_assessment_and_score(
+                            st.session_state.selected_articles.copy()
+                        )
                     else:
                         st.error(f"An error occurred: {result.get('error', 'Unknown error')}")
                     

--- a/utils/report_tools.py
+++ b/utils/report_tools.py
@@ -1,6 +1,12 @@
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
-from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph, Spacer
+from reportlab.platypus import (
+    SimpleDocTemplate,
+    Table,
+    TableStyle,
+    Paragraph,
+    Spacer,
+)
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib.units import inch
 from urllib.parse import unquote
@@ -10,10 +16,25 @@ from datetime import datetime
 import pandas as pd
 from openpyxl.utils import get_column_letter
 
+ASSESSMENT_PRIORITY = {"INCLUDE": 0, "OK": 1, "CUT": 2}
+
+
+def sort_by_assessment_and_score(articles):
+    """Sort articles by assessment category and score."""
+    return sorted(
+        articles,
+        key=lambda a: (
+            ASSESSMENT_PRIORITY.get(a.get("assessment", "CUT"), 2),
+            -a.get("assessment_score", 0),
+        ),
+    )
+
 def generate_pdf_report(articles):
     """Generate a detailed PDF report including evaluation info."""
     if not articles:
         return b""
+
+    articles = sort_by_assessment_and_score(articles)
 
     buffer = BytesIO()
     doc = SimpleDocTemplate(buffer, pagesize=letter)
@@ -103,6 +124,8 @@ def generate_csv_report(articles):
     if not articles:
         return b""
 
+    articles = sort_by_assessment_and_score(articles)
+
     output = BytesIO()
     data = []
     for article in articles:
@@ -134,6 +157,8 @@ def generate_excel_report(articles):
     """Generate an Excel report including evaluation info."""
     if not articles:
         return b""
+
+    articles = sort_by_assessment_and_score(articles)
 
     output = BytesIO()
     data = []


### PR DESCRIPTION
## Summary
- add `sort_by_assessment_and_score` helper to `report_tools`
- sort exported articles by assessment and score
- order displayed articles in `main.py`
- order selected articles in `main_agent_based.py`

## Testing
- `python -m py_compile main.py main_agent_based.py utils/report_tools.py`
- `pytest -q`