### PR TITLE
Switch settings panel to dialog

### DIFF
--- a/main.py
+++ b/main.py
@@ -246,16 +246,6 @@ def main():
             """
             <style>
             .settings-btn {position: fixed; top: 15px; right: 15px; z-index: 1000;}
-            .settings-modal {
-                position: fixed;
-                top: 50%;
-                left: 50%;
-                transform: translate(-50%, -50%);
-                background: rgba(31,31,48,0.95);
-                padding: 20px;
-                border-radius: 8px;
-                z-index: 1000;
-            }
             </style>
             """,
             unsafe_allow_html=True,
@@ -263,41 +253,41 @@ def main():
 
         st.markdown("<div class='settings-btn'>", unsafe_allow_html=True)
         if st.button("⚙️", key="settings_btn", help="Settings", type="secondary"):
-            st.session_state.show_settings = not st.session_state.show_settings
+            st.session_state.show_settings = True
         st.markdown("</div>", unsafe_allow_html=True)
 
+        fetch_button = False
         if st.session_state.show_settings:
-            st.markdown("<div class='settings-modal'>", unsafe_allow_html=True)
-            st.session_state.test_mode = st.toggle(
-                "Test Mode",
-                value=st.session_state.get('test_mode', False),
-                help="In Test Mode, only Wired.com is scanned"
-            )
-            col1, col2 = st.columns([2, 2])
-            with col1:
-                st.session_state.time_value = st.number_input(
-                    "Time Period",
-                    min_value=1,
-                    value=st.session_state.get("time_value", 1),
-                    step=1,
+            with st.dialog("Settings", key="settings_dialog"):
+                st.session_state.test_mode = st.toggle(
+                    "Test Mode",
+                    value=st.session_state.get('test_mode', False),
+                    help="In Test Mode, only Wired.com is scanned"
                 )
-            with col2:
-                unit_options = ["Days", "Weeks"]
-                default_index = unit_options.index(st.session_state.get("time_unit", "Weeks"))
-                st.session_state.time_unit = st.selectbox(
-                    "Unit",
-                    unit_options,
-                    index=default_index,
+                col1, col2 = st.columns([2, 2])
+                with col1:
+                    st.session_state.time_value = st.number_input(
+                        "Time Period",
+                        min_value=1,
+                        value=st.session_state.get("time_value", 1),
+                        step=1,
+                    )
+                with col2:
+                    unit_options = ["Days", "Weeks"]
+                    default_index = unit_options.index(st.session_state.get("time_unit", "Weeks"))
+                    st.session_state.time_unit = st.selectbox(
+                        "Unit",
+                        unit_options,
+                        index=default_index,
+                    )
+                fetch_button = st.button(
+                    "Fetch New Articles",
+                    disabled=st.session_state.is_fetching,
+                    type="primary",
+                    key="fetch_btn_main"
                 )
-            fetch_button = st.button(
-                "Fetch New Articles",
-                disabled=st.session_state.is_fetching,
-                type="primary",
-                key="fetch_btn_main"
-            )
-            st.markdown("</div>", unsafe_allow_html=True)
-        else:
-            fetch_button = False
+                if fetch_button:
+                    st.session_state.show_settings = False
 
         # Separate section for displaying results
         results_section = st.container()


### PR DESCRIPTION
## Summary
- show the options/settings in a modal dialog instead of a custom HTML overlay
- open the dialog at startup and when clicking the gear button
- close the dialog after clicking **Fetch New Articles**

## Testing
- `python -m py_compile main.py`