### PR TITLE
Fix re-run handling and update stubs

### DIFF
--- a/agents/search_agent.py
+++ b/agents/search_agent.py
@@ -237,14 +237,10 @@ def summarize_article(content):
 
 
 def validate_ai_relevance(article_data):
-codex/ensure-proper-file-endings-for-.py-and-.md
-    #Implementation needed here. Returns a dict with {'is_relevant':bool, 'reason':str}
-    return {"is_relevant": True, "reason": "Placeholder reason"}
-
     """Check if an article is relevant to AI topics."""
     try:
         return ce_validate_ai_relevance(article_data)
     except Exception as e:
         print(f"AI relevance validation failed: {e}")
         return {"is_relevant": True, "reason": "Validation error"}
-main
+

--- a/main_agent_based.py
+++ b/main_agent_based.py
@@ -49,7 +49,7 @@ if 'initialized' not in st.session_state:
                 'max_report_articles': 10
             }
         }
-        
+        st.session_state.orchestrator_config = default_config
         st.session_state.orchestrator = Orchestrator(default_config)
         logger.info("Session state initialized successfully")
     except Exception as e:
@@ -177,6 +177,9 @@ def main():
         # Clear previous results when starting a new fetch
         if fetch_button:
             st.session_state.is_fetching = True
+            st.session_state.orchestrator = Orchestrator(
+                st.session_state.get('orchestrator_config', {})
+            )
             st.session_state.pdf_data = None
             st.session_state.csv_data = None
             st.session_state.excel_data = None

--- a/openai_stub.py
+++ b/openai_stub.py
@@ -1,0 +1,3 @@
+class Dummy:
+    def __init__(self, *args, **kwargs):
+        pass

--- a/utils/ai_analyzer.py
+++ b/utils/ai_analyzer.py
@@ -14,7 +14,10 @@ from utils.config_manager import load_config, DEFAULT_CONFIG
 logger = logging.getLogger(__name__)
 
 # Initialize OpenAI client
-client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+try:
+    client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+except Exception:
+    client = None
 
 # Simple in-memory cache for API responses
 _cache = {}


### PR DESCRIPTION
## Summary
- fix `validate_ai_relevance` helper in `search_agent`
- add minimal `openai_stub` for tests
- avoid OpenAI initialization errors in `ai_analyzer`
- recreate `Orchestrator` when fetching again so new configs apply

## Testing
- `pytest -q`