### PR TITLE
Fix settings drawer closing

### DIFF
--- a/main.py
+++ b/main.py
@@ -239,6 +239,10 @@ def main():
         # Add simple particle effect background
         add_simple_particles()
 
+        # Ensure settings drawer is hidden while fetching
+        if st.session_state.get("is_fetching", False):
+            st.session_state.show_settings = False
+
         # Custom header with settings button
         st.markdown(
             """
@@ -267,7 +271,14 @@ def main():
 
         header_col1, header_col2 = st.columns([1, 11])
         with header_col1:
-            if st.button("⚙️", key="settings_btn", help="Settings", type="secondary"):
+            gear_disabled = st.session_state.get("is_fetching", False)
+            if st.button(
+                "⚙️",
+                key="settings_btn",
+                help="Settings",
+                type="secondary",
+                disabled=gear_disabled,
+            ):
                 st.session_state.show_settings = not st.session_state.show_settings
         with header_col2:
             st.title("AI News Aggregation System")

--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -54,6 +54,16 @@ def render_settings_drawer():
         .settings-content {
             margin-top: 10px;
         }
+        .close-btn {
+            position: absolute;
+            top: 8px;
+            right: 8px;
+            background: transparent;
+            border: none;
+            color: #ffffff;
+            font-size: 20px;
+            cursor: pointer;
+        }
         </style>
         <script>
         window.hideSettingsDrawer = function() {
@@ -78,6 +88,7 @@ def render_settings_drawer():
         f"""
         <div class="settings-overlay{'visible' if st.session_state.show_settings else ''}" onclick="window.hideSettingsDrawer();"></div>
         <div class="settings-drawer{'visible' if st.session_state.show_settings else ''}">
+            <button class="close-btn" onclick="window.hideSettingsDrawer();">&times;</button>
         """,
         unsafe_allow_html=True
     )
@@ -113,6 +124,7 @@ def render_settings_drawer():
                 disabled=st.session_state.get("is_fetching", False),
                 type="primary",
                 key="fetch_btn",
+                on_click=lambda: st.session_state.update(show_settings=False),
             )
 
             config_saved = False


### PR DESCRIPTION
## Summary
- ensure settings drawer hides while fetching
- disable gear icon when fetch is running
- add close button to drawer and hide it when fetching begins

## Testing
- `pytest -q`