### PR TITLE
Fix fetch button not starting

### DIFF
--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -124,7 +124,6 @@ def render_settings_drawer():
                 disabled=st.session_state.get("is_fetching", False),
                 type="primary",
                 key="fetch_btn",
-                on_click=lambda: st.session_state.update(show_settings=False),
             )
 
             config_saved = False


### PR DESCRIPTION
## Summary
- remove `on_click` from `Fetch New Articles` button so that its state is returned

## Testing
- `pytest -q`