### PR TITLE
Close settings drawer when fetching starts

### DIFF
--- a/main.py
+++ b/main.py
@@ -296,6 +296,8 @@ def main():
         if fetch_button:
             # First hide settings panel
             st.session_state.show_settings = False
+            # Close the drawer via query param so it disappears on rerun
+            st.experimental_set_query_params(close_settings="1")
             # Then reset state for a new scan
             st.session_state.is_fetching = True
             st.session_state.pdf_data = None

--- a/main_agent_based.py
+++ b/main_agent_based.py
@@ -138,6 +138,7 @@ def main():
         # Clear previous results when starting a new fetch
         if fetch_button:
             st.session_state.show_settings = False
+            st.experimental_set_query_params(close_settings="1")
             st.session_state.is_fetching = True
             st.session_state.orchestrator = Orchestrator(
                 st.session_state.get('orchestrator_config', {})

--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -125,6 +125,13 @@ def render_settings_drawer():
                 type="primary",
                 key="fetch_btn",
             )
+            if fetch_button:
+                # Hide the drawer immediately when starting a fetch
+                st.session_state.show_settings = False
+                st.markdown(
+                    "<script>window.hideSettingsDrawer && window.hideSettingsDrawer();</script>",
+                    unsafe_allow_html=True,
+                )
 
             config_saved = False
             with st.expander("Configuration", expanded=False):


### PR DESCRIPTION
## Summary
- ensure the settings drawer hides when starting a fetch
- persist closing state via query parameter for both app entry points

## Testing
- `pytest -q`