### PR TITLE
Fix timeframe filtering

### DIFF
--- a/agents/crawler_agent.py
+++ b/agents/crawler_agent.py
@@ -52,7 +52,10 @@ class CrawlerAgent(BaseAgent):
         """Process a list of source URLs to find AI-related articles"""
         if cutoff_time is None:
             days = self.config.get('default_days', 7)
-            cutoff_time = datetime.now() - timedelta(days=days)
+            cutoff_time = (
+                datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                - timedelta(days=days)
+            )
             
         self.log_event(f"Starting crawl of {len(source_urls)} sources with cutoff: {cutoff_time}")
         
@@ -147,15 +150,11 @@ class CrawlerAgent(BaseAgent):
                 
             # Validate date against cutoff
             try:
-                article_date = datetime.strptime(metadata['date'], '%Y-%m-%d')
-                article_date = pytz.UTC.localize(article_date)
+                article_date = datetime.strptime(metadata['date'], '%Y-%m-%d').date()
+                cutoff_date = cutoff_time.date()
 
-                # Ensure cutoff time is timezone aware
-                if not cutoff_time.tzinfo:
-                    cutoff_time = pytz.UTC.localize(cutoff_time)
-
-                # Only include articles after cutoff date
-                if article_date >= cutoff_time:
+                # Only include articles on or after cutoff date
+                if article_date >= cutoff_date:
                     self.log_event(f"Found AI article within timeframe: {title}")
                     return {
                         'title': title,

--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -66,8 +66,13 @@ class Orchestrator:
         try:
             # Calculate cutoff time
             days_to_subtract = time_period * 7 if time_unit == "Weeks" else time_period
-            cutoff_time = datetime.now() - timedelta(days=days_to_subtract)
-            self.update_status(f"Time period: {time_period} {time_unit}, Cutoff: {cutoff_time}")
+            cutoff_time = (
+                datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+                - timedelta(days=days_to_subtract)
+            )
+            self.update_status(
+                f"Time period: {time_period} {time_unit}, Cutoff: {cutoff_time}"
+            )
             
             # Step 1: Crawl sources for articles
             self.update_status("Crawling sources for AI articles...")

--- a/main.py
+++ b/main.py
@@ -335,7 +335,12 @@ def main():
                         days_to_subtract = st.session_state.time_value
 
                     # Create a cutoff_time in the past
-                    cutoff_time = datetime.now() - timedelta(days=days_to_subtract)
+                    cutoff_time = (
+                        datetime.now().replace(
+                            hour=0, minute=0, second=0, microsecond=0
+                        )
+                        - timedelta(days=days_to_subtract)
+                    )
                     logger.info(
                         f"Time period: {st.session_state.time_value} {st.session_state.time_unit}, Cutoff: {cutoff_time} (Including articles newer than this date)"
                     )

--- a/utils/common.py
+++ b/utils/common.py
@@ -19,7 +19,11 @@ def validate_timeframe(date_str, cutoff_date):
     Validates if a date is within the specified timeframe
     """
     try:
-        article_date = datetime.strptime(date_str, '%Y-%m-%d')
-        return article_date >= cutoff_date
-    except:
+        article_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+        if isinstance(cutoff_date, datetime):
+            cutoff = cutoff_date.date()
+        else:
+            cutoff = cutoff_date
+        return article_date >= cutoff
+    except Exception:
         return False

--- a/utils/search_tools.py
+++ b/utils/search_tools.py
@@ -24,8 +24,9 @@ def search_web(keywords, cutoff_date):
             results = client.search(params).get("news_results", [])
 
             for result in results:
-                pub_date = datetime.strptime(result['date'], '%Y-%m-%d')
-                if pub_date >= cutoff_date:
+                pub_date = datetime.strptime(result['date'], '%Y-%m-%d').date()
+                c_date = cutoff_date.date() if isinstance(cutoff_date, datetime) else cutoff_date
+                if pub_date >= c_date:
                     articles.append({
                         'title': result['title'],
                         'url': result['link'],
@@ -64,16 +65,17 @@ def search_arxiv(cutoff_date):
             summary = entry.findtext("a:summary", default="", namespaces=ns).strip()
 
             try:
-                pub_date = datetime.strptime(date_text[:10], "%Y-%m-%d")
+                pub_date = datetime.strptime(date_text[:10], "%Y-%m-%d").date()
             except Exception:
-                pub_date = cutoff_date
+                pub_date = cutoff_date.date() if isinstance(cutoff_date, datetime) else cutoff_date
 
-            if pub_date >= cutoff_date:
+            c_date = cutoff_date.date() if isinstance(cutoff_date, datetime) else cutoff_date
+            if pub_date >= c_date:
                 articles.append({
                     "title": title,
                     "url": link,
                     "source": "arXiv",
-                    "published_date": pub_date,
+                    "published_date": datetime.combine(pub_date, datetime.min.time()),
                     "content": summary,
                 })
     except Exception as e:


### PR DESCRIPTION
## Summary
- ensure date comparisons ignore time portion and compare full days
- start cutoff date at the beginning of the day in UI, orchestrator and crawler
- update article date filtering in crawler and search utilities
- adjust timeframe validator

## Testing
- `pytest -q`