### PR TITLE
Fix date parsing so last-week filter works

### DIFF
--- a/tests/test_search_agent.py
+++ b/tests/test_search_agent.py
@@ -14,6 +14,9 @@ class _OpenAI:
         pass
 openai_mod.OpenAI = _OpenAI
 sys.modules.setdefault('openai', openai_mod)
+yaml_mod = types.ModuleType('yaml')
+yaml_mod.safe_load = lambda *a, **k: {}
+sys.modules.setdefault('yaml', yaml_mod)
 requests_mod = types.ModuleType('requests')
 class _Response:
     status_code = 200

--- a/utils/common.py
+++ b/utils/common.py
@@ -14,6 +14,25 @@ def format_date(date_obj):
     """
     return date_obj.strftime('%Y-%m-%d')
 
+def parse_date(date_str):
+    """Parse a date string in various common formats."""
+    formats = [
+        "%Y-%m-%d",
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S%z",
+    ]
+    for fmt in formats:
+        try:
+            return datetime.strptime(date_str, fmt)
+        except Exception:
+            continue
+    try:
+        # datetime.fromisoformat supports many ISO variants
+        return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+    except Exception:
+        return None
+
 def validate_timeframe(date_str, cutoff_date):
     """
     Validates if a date is within the specified timeframe

--- a/utils/content_extractor.py
+++ b/utils/content_extractor.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 import logging
 import time
 from datetime import datetime, timedelta
+from utils.common import parse_date
 import pytz
 from urllib.parse import urljoin
 import re
@@ -310,11 +311,17 @@ def process_link(link, source_url, ai_regex, cutoff_time, seen_urls):
         if not metadata:
             return None
 
-        # Parse the article date
+        # Parse the article date using flexible formats
         try:
-            article_date = datetime.strptime(metadata['date'], '%Y-%m-%d')
+            article_date = parse_date(metadata['date'])
+            if not article_date:
+                raise ValueError(f"Unrecognized date format: {metadata['date']}")
+
             # Add UTC timezone to match cutoff_time
-            article_date = pytz.UTC.localize(article_date)
+            if article_date.tzinfo:
+                article_date = article_date.astimezone(pytz.UTC)
+            else:
+                article_date = pytz.UTC.localize(article_date)
 
             # Ensure cutoff_time is timezone aware
             if not cutoff_time.tzinfo:


### PR DESCRIPTION
## Summary
- add `parse_date` utility to handle ISO date formats
- use `parse_date` in `extract_metadata` path to keep recent articles
- stub `yaml` module in search agent tests

## Testing
- `pytest -q`