### PR TITLE
Add article categorization

### DIFF
--- a/data/criteria/categorization_framework.txt
+++ b/data/criteria/categorization_framework.txt
@@ -1,0 +1,43 @@
+Crocs Articles Categorization Framework
+1. Content & Creative
+Use of generative AI to enhance how brands engage, convert, and retain consumers through:
+- Dynamic content generation on product pages for personalization, SEO, and UX
+- Scalable creative production of visuals, videos, ads, and branded assets
+- AI-optimized marketing, designed for visibility within LLMs and AI-driven discovery
+- Automated ad workflows, where AI handles campaign creation, targeting, and performance
+2. Business Intelligence (BI)
+Applications of GenAI in enhancing decision-making through data, including:
+- Conversational BI tools and dashboards
+- Advanced sales forecasting
+- AI-driven merchandising, allocation, and replenishment
+- Development and tracking of digital KPIs
+- Broader applications of GenAI for smarter business insights
+3. Product Design & Manufacturing
+Use of GenAI in product development processes, particularly in:
+- Ideation and concept generation
+- New product development
+4. Supply Chain, Distribution & Logistics
+GenAI-driven improvements in end-to-end supply chain operations, such as:
+- Demand forecasting and inventory planning
+- Warehouse and logistics optimization
+- Shipping time and route management
+- Forecasting related to supply chain
+- Reduction of manual work across distribution networks
+5. Enterprise Chat & Workplace AI
+Use of GenAI in enterprise communication and collaboration tools, including:
+- ChatGPT for Enterprise or similar deployments (e.g., Perplexity, Gemini, Anthropic)
+- Custom GPTs and internal knowledge assistants
+- SaaS/startup solutions aimed at enterprise productivity
+- Case studies from large-scale enterprise rollouts
+6. Other Applications
+- Customer service and engagement tools
+- Tech and software development use cases
+- Organizational efficiency, operations, and HR tools
+7. Competitor Updates
+GenAI-related developments specific to key industry players:
+- Adidas
+- Nike
+- Deckers
+- Skechers
+- OOFOS
+- Puma

--- a/utils/report_tools.py
+++ b/utils/report_tools.py
@@ -78,6 +78,12 @@ def generate_pdf_report(articles):
         takeaway = article.get('takeaway', 'No takeaway available')
         content.append(Paragraph(f"<b>Key Takeaway:</b> {takeaway}", takeaway_style))
 
+        category = article.get('category', 'N/A')
+        justification = article.get('category_justification', 'N/A')
+        content.append(Paragraph(f"<b>Category:</b> {category}", normal_style))
+        content.append(Paragraph(f"<b>Justification:</b> {justification}", normal_style))
+        content.append(Spacer(1, 6))
+
         crit_results = article.get('criteria_results', [])
         if crit_results:
             table_data = [["Criteria", "Status", "Notes"]]
@@ -141,6 +147,8 @@ def generate_csv_report(articles):
             'Date': article.get('date', ''),
             'Source': article.get('source', ''),
             'Takeaway': article.get('takeaway', ''),
+            'Category': article.get('category', 'N/A'),
+            'Category Justification': article.get('category_justification', 'N/A'),
             'Assessment': article.get('assessment', ''),
             'Score': article.get('assessment_score', 0),
         }
@@ -175,6 +183,8 @@ def generate_excel_report(articles):
             'Date': article.get('date', ''),
             'Source': article.get('source', ''),
             'Takeaway': article.get('takeaway', ''),
+            'Category': article.get('category', 'N/A'),
+            'Category Justification': article.get('category_justification', 'N/A'),
             'Assessment': article.get('assessment', ''),
             'Score': article.get('assessment_score', 0),
         }


### PR DESCRIPTION
## Summary
- categorize articles using a new LLM prompt and framework
- store category and justification in the database
- show categorization in the Streamlit UI
- include categorization in PDF/CSV/Excel reports
- add categorization framework text

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842a684c7b0832c8a49c2f825ed66c8