### PR TITLE
Fix time period input state key

### DIFF
--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -104,12 +104,12 @@ def render_settings_drawer():
 
             col1, col2 = st.columns([2, 2])
             with col1:
-                st.session_state.time_value = st.number_input(
+                st.number_input(
                     "Time Period",
                     min_value=1,
                     value=st.session_state.get("time_value", 1),
                     step=1,
-                    key="time_value_input",
+                    key="time_value",
                 )
             with col2:
                 unit_options = ["Days", "Weeks"]


### PR DESCRIPTION
## Summary
- fix numeric input for time period in the settings drawer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c26cf0e8832c95d7d6eb21648c24