### PR TITLE
Adjust PDF report layout

### DIFF
--- a/agents/report_agent.py
+++ b/agents/report_agent.py
@@ -195,8 +195,15 @@ class ReportAgent(BaseAgent):
                 date = article.get('date', 'Unknown date')
                 source = article.get('source', 'Unknown source')
                 content.append(Paragraph(f"Published: {date} | Source: {source}", normal_style))
+
+                category = article.get('category', 'N/A')
+                content.append(Paragraph(f"<b>Category:</b> {category}", article_style))
+
+                assessment = article.get('assessment', 'N/A')
+                score = article.get('assessment_score', 0)
+                content.append(Paragraph(f"<b>Assessment:</b> {assessment} (Score: {score}%)", article_style))
                 content.append(Spacer(1, 6))
-                
+
                 # Takeaway
                 takeaway = article.get('takeaway', 'No takeaway available')
                 content.append(Paragraph(f"<b>Key Takeaway:</b> {takeaway}", takeaway_style))
@@ -237,9 +244,8 @@ class ReportAgent(BaseAgent):
                     content.append(table)
                     content.append(Spacer(1, 6))
 
-                assessment = article.get('assessment', 'N/A')
-                score = article.get('assessment_score', 0)
-                content.append(Paragraph(f"<b>Assessment:</b> {assessment} (Score: {score}%)", article_style))
+                justification = article.get('category_justification', 'N/A')
+                content.append(Paragraph(f"<b>Justification:</b> {justification}", article_style))
 
                 # Add space between articles
                 content.append(Spacer(1, 20))

--- a/utils/report_tools.py
+++ b/utils/report_tools.py
@@ -73,16 +73,17 @@ def generate_pdf_report(articles):
         date = article.get('date', 'Unknown date')
         source = article.get('source', 'Unknown source')
         content.append(Paragraph(f"Published: {date} | Source: {source}", normal_style))
+
+        category = article.get('category', 'N/A')
+        content.append(Paragraph(f"<b>Category:</b> {category}", normal_style))
+
+        assessment = article.get('assessment', 'N/A')
+        score = article.get('assessment_score', 0)
+        content.append(Paragraph(f"<b>Assessment:</b> {assessment} (Score: {score}%)", normal_style))
         content.append(Spacer(1, 6))
 
         takeaway = article.get('takeaway', 'No takeaway available')
         content.append(Paragraph(f"<b>Key Takeaway:</b> {takeaway}", takeaway_style))
-
-        category = article.get('category', 'N/A')
-        justification = article.get('category_justification', 'N/A')
-        content.append(Paragraph(f"<b>Category:</b> {category}", normal_style))
-        content.append(Paragraph(f"<b>Justification:</b> {justification}", normal_style))
-        content.append(Spacer(1, 6))
 
         crit_results = article.get('criteria_results', [])
         if crit_results:
@@ -115,9 +116,8 @@ def generate_pdf_report(articles):
             content.append(table)
             content.append(Spacer(1, 6))
 
-        assessment = article.get('assessment', 'N/A')
-        score = article.get('assessment_score', 0)
-        content.append(Paragraph(f"<b>Assessment:</b> {assessment} (Score: {score}%)", normal_style))
+        justification = article.get('category_justification', 'N/A')
+        content.append(Paragraph(f"<b>Justification:</b> {justification}", normal_style))
         content.append(Spacer(1, 20))
 
     doc.build(content)


### PR DESCRIPTION
## Summary
- move article category and assessment details next to the publication date in PDF reports
- show criteria results and justification after the takeaway section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c36df95c832c8c9ed3f9832a4aa0