### PR TITLE
Fix Session State time_value warning

### DIFF
--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -107,7 +107,6 @@ def render_settings_drawer():
                 st.number_input(
                     "Time Period",
                     min_value=1,
-                    value=st.session_state.get("time_value", 1),
                     step=1,
                     key="time_value",
                 )


### PR DESCRIPTION
## Summary
- ensure time period input uses session state value without default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c6e40fa8832cacbe4935ba2f42e5