### PR TITLE
Shrink takeaway text

### DIFF
--- a/main.py
+++ b/main.py
@@ -503,8 +503,8 @@ def main():
                     takeaway_text = article.get('takeaway', 'No takeaway available')
                     takeaway_text = clean_takeaway(takeaway_text)
 
-                    # Display the takeaway with custom formatting
-                    st.subheader("Takeaway")
+                    # Display the takeaway with smaller font
+                    st.markdown("**Takeaway**")
 
                     # Custom CSS to ensure proper text wrapping
                     st.markdown("""
@@ -520,6 +520,7 @@ def main():
                         max-width: 100%;
                         overflow-wrap: break-word;
                         line-height: 1.5;
+                        font-size: 0.9em;
                     }
                     </style>
                     """, unsafe_allow_html=True)

--- a/project_export.xml
+++ b/project_export.xml
@@ -497,7 +497,7 @@ def main():
                     takeaway_text = clean_takeaway(takeaway_text)
 
                     # Display the takeaway with custom formatting
-                    st.subheader("Takeaway")
+                    st.markdown("**Takeaway**")
 
                     # Custom CSS to ensure proper text wrapping
                     st.markdown("""
@@ -513,6 +513,7 @@ def main():
                         max-width: 100%;
                         overflow-wrap: break-word;
                         line-height: 1.5;
+                        font-size: 0.9em;
                     }
                     </style>
                     """, unsafe_allow_html=True)


### PR DESCRIPTION
## Summary
- shrink takeaway text to match category font size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c79655b8832ca071483b2050564a