### PR TITLE
Add URL manager to settings

### DIFF
--- a/config.json
+++ b/config.json
@@ -66,5 +66,41 @@
       "meta"
     ]
   },
-  "takeaway_rubric": "1. For each article, generate a single takeaway in the form of a concise paragraph (3\u20134 sentences, 70\u201390 words). Avoid long sentences.\n2. The takeaway should highlight the strategic relevance of the news for AI leaders in the retail industry.\n3. Mention specific company names, AI tools, or platforms covered in the article.\n4. Include quantitative and qualitative data such as user numbers, revenue growth, conversion rates, operational improvements, or customer behavior insights, only if stated in the article. Never fabricate or estimate numbers.\n5. Emphasize business impact and strategic benefits: for example, content automation, creative ads generation, improved customer experience, supply chain efficiency, product innovation, product manufacturing, sales growth, personalization, or cost reduction.\n6. Use clear, digestible language that avoids technical jargon.\n7. Explain why the news update matters for AI leaders in retail, such as implications for e-commerce, in-store experience, logistics, or customer engagement.\n8. Add a human or strategic perspective, like leadership vision, transformation goals, or market shifts.\n9. Don\u2019t use bullet points. The takeaway must be written in paragraph form.\n10. There shouldn\u2019t be any vague or visionary statements. Always ground the insight in specific content from the article.\n11. Never overtly or explicitly mention your target reader, the AI leader in the retail industry."
+  "takeaway_rubric": "1. For each article, generate a single takeaway in the form of a concise paragraph (3\u20134 sentences, 70\u201390 words). Avoid long sentences.\n2. The takeaway should highlight the strategic relevance of the news for AI leaders in the retail industry.\n3. Mention specific company names, AI tools, or platforms covered in the article.\n4. Include quantitative and qualitative data such as user numbers, revenue growth, conversion rates, operational improvements, or customer behavior insights, only if stated in the article. Never fabricate or estimate numbers.\n5. Emphasize business impact and strategic benefits: for example, content automation, creative ads generation, improved customer experience, supply chain efficiency, product innovation, product manufacturing, sales growth, personalization, or cost reduction.\n6. Use clear, digestible language that avoids technical jargon.\n7. Explain why the news update matters for AI leaders in retail, such as implications for e-commerce, in-store experience, logistics, or customer engagement.\n8. Add a human or strategic perspective, like leadership vision, transformation goals, or market shifts.\n9. Don\u2019t use bullet points. The takeaway must be written in paragraph form.\n10. There shouldn\u2019t be any vague or visionary statements. Always ground the insight in specific content from the article.\n11. Never overtly or explicitly mention your target reader, the AI leader in the retail industry.",
+  "full_scan_urls": [
+    "https://wwd.com/business-news/technology/",
+    "https://sourcingjournal.com/tag/byte-sized-ai/",
+    "https://footwearnews.com/c/business/technology/",
+    "https://www.retaildive.com/topic/technology/",
+    "https://www.retailbrew.com",
+    "https://consumergoods.com/artificial-intelligence",
+    "https://www.adweek.com/category/emerging-tech/",
+    "https://adage.com/live-blog/ai-marketing-updates-chatgpt-dall-e-2-and-other-tools",
+    "https://ppc.land/tag/ai/",
+    "https://techcrunch.com/category/artificial-intelligence/",
+    "https://techcrunch.com/tag/retail/",
+    "https://www.digitalcommerce360.com/topic-artificial-intelligence-ecommerce/",
+    "https://www.retailtouchpoints.com/",
+    "https://chainstoreage.com/technology",
+    "https://www.warc.com/feed",
+    "https://www.campaignlive.com/us/just-published-on-campaign/martech",
+    "https://www.virtasant.com/ai-today",
+    "https://aiexpertnetwork.notion.site/AI-Transformation-Case-Studies-779878d924fa466186071b7939d7599a",
+    "https://www.bain.com/insights/?filters=offerings(2007762)",
+    "https://retailwire.com/tag/artificial-intelligence/",
+    "https://www.wsj.com/tech/ai",
+    "https://sloanreview.mit.edu/topic/ai-machine-learning/",
+    "https://hbr.org/topic/subject/generative-ai",
+    "https://hbr.org/topic/subject/ai-and-machine-learning",
+    "https://www.footwearinnovationnews.com/",
+    "https://venturebeat.com/category/ai/",
+    "https://www.google.co.in/alerts#1:7",
+    "https://www.retailcustomerexperience.com/topics/omnichannel-retail/",
+    "http://www.diginomica.com/",
+    "https://www.technologyreview.com/topic/artificial-intelligence/",
+    "https://www.wired.com/tag/artificial-intelligence/"
+  ],
+  "test_scan_urls": [
+    "https://techcrunch.com/category/artificial-intelligence/"
+  ]
 }

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -33,7 +33,43 @@ DEFAULT_CONFIG = {
         "4. Only use statistics from the source text - never fabricate numbers\n"
         "5. Highlight business impacts and strategic benefits of the AI technology\n"
         "6. Use clear language without technical jargon"
-    )
+    ),
+    "full_scan_urls": [
+        "https://wwd.com/business-news/technology/",
+        "https://sourcingjournal.com/tag/byte-sized-ai/",
+        "https://footwearnews.com/c/business/technology/",
+        "https://www.retaildive.com/topic/technology/",
+        "https://www.retailbrew.com",
+        "https://consumergoods.com/artificial-intelligence",
+        "https://www.adweek.com/category/emerging-tech/",
+        "https://adage.com/live-blog/ai-marketing-updates-chatgpt-dall-e-2-and-other-tools",
+        "https://ppc.land/tag/ai/",
+        "https://techcrunch.com/category/artificial-intelligence/",
+        "https://techcrunch.com/tag/retail/",
+        "https://www.digitalcommerce360.com/topic-artificial-intelligence-ecommerce/",
+        "https://www.retailtouchpoints.com/",
+        "https://chainstoreage.com/technology",
+        "https://www.warc.com/feed",
+        "https://www.campaignlive.com/us/just-published-on-campaign/martech",
+        "https://www.virtasant.com/ai-today",
+        "https://aiexpertnetwork.notion.site/AI-Transformation-Case-Studies-779878d924fa466186071b7939d7599a",
+        "https://www.bain.com/insights/?filters=offerings(2007762)",
+        "https://retailwire.com/tag/artificial-intelligence/",
+        "https://www.wsj.com/tech/ai",
+        "https://sloanreview.mit.edu/topic/ai-machine-learning/",
+        "https://hbr.org/topic/subject/generative-ai",
+        "https://hbr.org/topic/subject/ai-and-machine-learning",
+        "https://www.footwearinnovationnews.com/",
+        "https://venturebeat.com/category/ai/",
+        "https://www.google.co.in/alerts#1:7",
+        "https://www.retailcustomerexperience.com/topics/omnichannel-retail/",
+        "http://www.diginomica.com/",
+        "https://www.technologyreview.com/topic/artificial-intelligence/",
+        "https://www.wired.com/tag/artificial-intelligence/"
+    ],
+    "test_scan_urls": [
+        "https://techcrunch.com/category/artificial-intelligence/"
+    ]
 }
 
 

--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -84,6 +84,8 @@ def render_settings_drawer():
 
     if "show_settings" not in st.session_state:
         st.session_state.show_settings = False
+    if "show_url_modal" not in st.session_state:
+        st.session_state.show_url_modal = False
 
     st.markdown(
         f"""
@@ -125,6 +127,12 @@ def render_settings_drawer():
                 type="primary",
                 key="fetch_btn",
             )
+            url_button = st.button(
+                "URL Management",
+                disabled=st.session_state.get("is_fetching", False),
+                type="primary",
+                key="url_mgmt_btn",
+            )
             if fetch_button:
                 # Hide the drawer immediately when starting a fetch
                 st.session_state.show_settings = False
@@ -132,6 +140,8 @@ def render_settings_drawer():
                     "<script>window.hideSettingsDrawer && window.hideSettingsDrawer();</script>",
                     unsafe_allow_html=True,
                 )
+            if url_button:
+                st.session_state.show_url_modal = True
 
             config_saved = False
             with st.expander("Configuration", expanded=False):
@@ -188,6 +198,24 @@ def render_settings_drawer():
                     config_saved = True
                     st.success("Configuration saved.")
 
+            if st.session_state.show_url_modal:
+                from utils.config_manager import load_config, save_config
+                cfg = load_config()
+                full_default = "\n".join(cfg.get("full_scan_urls", []))
+                test_default = "\n".join(cfg.get("test_scan_urls", []))
+                with st.modal("URL Management"):
+                    with st.form("url_mgmt_form"):
+                        left, right = st.columns(2)
+                        full_text = left.text_area("Full Scan URLs", full_default, height=300)
+                        test_text = right.text_area("Test Scan URLs", test_default, height=300)
+                        saved = st.form_submit_button("Save")
+                    if saved:
+                        cfg["full_scan_urls"] = [u.strip() for u in full_text.splitlines() if u.strip()]
+                        cfg["test_scan_urls"] = [u.strip() for u in test_text.splitlines() if u.strip()]
+                        save_config(cfg)
+                        st.session_state.show_url_modal = False
+                        st.success("URL configuration saved.")
+                    st.button("Close", key="close_url_modal", on_click=lambda: st.session_state.update({"show_url_modal": False}))
             return fetch_button, config_saved
 
     return None, False


### PR DESCRIPTION
## Summary
- add source URL lists to config and defaults
- support loading source URLs from configuration
- add URL Management modal in settings UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842d9d364e8832cb58f33075e829971