### PR TITLE
Revamp lookback period handling

### DIFF
--- a/agents/orchestrator.py
+++ b/agents/orchestrator.py
@@ -46,14 +46,13 @@ class Orchestrator:
         self.status_messages.insert(0, status_msg)
         logger.info(f"Status: {message}")
         
-    def run_workflow(self, source_urls, time_period=7, time_unit="Days"):
+    def run_workflow(self, source_urls, lookback_days=7):
         """
         Run the complete news aggregation workflow with all agents
         
         Args:
             source_urls: List of source URLs to search for articles
-            time_period: Number of time units to look back
-            time_unit: "Days" or "Weeks"
+            lookback_days: Number of days to look back
             
         Returns:
             Dict containing workflow results
@@ -65,13 +64,12 @@ class Orchestrator:
         
         try:
             # Calculate cutoff time
-            days_to_subtract = time_period * 7 if time_unit == "Weeks" else time_period
             cutoff_time = (
                 datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-                - timedelta(days=days_to_subtract)
+                - timedelta(days=lookback_days)
             )
             self.update_status(
-                f"Time period: {time_period} {time_unit}, Cutoff: {cutoff_time}"
+                f"Lookback: {lookback_days} days, Cutoff: {cutoff_time}"
             )
             
             # Step 1: Crawl sources for articles

--- a/agents/search_agent.py
+++ b/agents/search_agent.py
@@ -13,7 +13,7 @@ import pytz
 class SearchAgent:
     def __init__(self, config):
         self.config = config
-        self.timeframe_days = config['search_timeframe_days']
+        self.timeframe_days = config.get('lookback_days', config.get('search_timeframe_days', 7))
         self.client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
         self.model = "o3-mini"
         self.min_articles = 6
@@ -89,8 +89,7 @@ class SearchAgent:
         Aggregates articles from all configured sources with optimized validation flow
         """
         articles = []
-        days_to_subtract = self.timeframe_days * 7 if self.config.get('time_unit') == "Weeks" else self.timeframe_days
-        cutoff_time = datetime.now() - timedelta(days=days_to_subtract)
+        cutoff_time = datetime.now() - timedelta(days=self.timeframe_days)
 
         try:
             keywords = self.extract_keywords_from_criteria(criteria_text)[:self.max_keywords]

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ from utils.report_tools import (
     sort_by_assessment_and_score,
 )
 from utils.simple_particles import add_simple_particles
+from utils.common import calculate_lookback_days
 from agents.evaluation_agent import EvaluationAgent
 import pandas as pd
 import json
@@ -49,6 +50,9 @@ if 'initialized' not in st.session_state:
         st.session_state.show_settings = True  # Show settings panel on first load
         st.session_state.time_value = 1  # Default time period value
         st.session_state.time_unit = "Weeks"  # Default time period unit
+        st.session_state.lookback_days = calculate_lookback_days(
+            st.session_state.time_value, st.session_state.time_unit
+        )
         st.session_state.initialized = True
         st.session_state.last_update = datetime.now()
         st.session_state.scan_complete = False  # Flag to track if a scan has completed
@@ -337,11 +341,8 @@ def main():
                     end_idx = min(start_idx + batch_size, len(sources))
                     current_batch = sources[start_idx:end_idx]
 
-                    # Calculate cutoff time based on selected unit - looking BACK in time
-                    if st.session_state.time_unit == "Weeks":
-                        days_to_subtract = st.session_state.time_value * 7
-                    else:  # Days
-                        days_to_subtract = st.session_state.time_value
+                    # Calculate cutoff time using unified lookback days
+                    days_to_subtract = st.session_state.lookback_days
 
                     # Create a cutoff_time in the past
                     cutoff_time = (
@@ -352,7 +353,7 @@ def main():
                     )
                     current_date = datetime.now().strftime('%Y-%m-%d')
                     logger.info(
-                        f"Today is: {current_date}, Time period: {st.session_state.time_value} {st.session_state.time_unit}, Cutoff: {cutoff_time} (Including articles from {(cutoff_time + timedelta(days=1)).strftime('%Y-%m-%d')} to {current_date})"
+                        f"Today is: {current_date}, Lookback: {st.session_state.lookback_days} days, Cutoff: {cutoff_time} (Including articles from {(cutoff_time + timedelta(days=1)).strftime('%Y-%m-%d')} to {current_date})"
                     )
 
                     # Process current batch

--- a/main_agent_based.py
+++ b/main_agent_based.py
@@ -6,6 +6,7 @@ import logging
 from agents.orchestrator import Orchestrator
 from utils.simple_particles import add_simple_particles
 from utils.report_tools import sort_by_assessment_and_score
+from utils.common import calculate_lookback_days
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -28,6 +29,9 @@ if 'initialized' not in st.session_state:
         st.session_state.show_settings = True  # Display settings modal on first load
         st.session_state.time_value = 1  # Default time period value
         st.session_state.time_unit = "Weeks"  # Default time period unit
+        st.session_state.lookback_days = calculate_lookback_days(
+            st.session_state.time_value, st.session_state.time_unit
+        )
         st.session_state.initialized = True
         st.session_state.last_update = datetime.now()
         st.session_state.scan_complete = False
@@ -165,8 +169,7 @@ def main():
                     # Run the orchestrated workflow
                     result = st.session_state.orchestrator.run_workflow(
                         sources,
-                        time_period=st.session_state.time_value,
-                        time_unit=st.session_state.time_unit
+                        lookback_days=st.session_state.lookback_days
                     )
                     
                     # Update UI with status messages

--- a/utils/common.py
+++ b/utils/common.py
@@ -33,6 +33,12 @@ def parse_date(date_str):
     except Exception:
         return None
 
+def calculate_lookback_days(value: int, unit: str) -> int:
+    """Convert a user supplied time value and unit into total days."""
+    if unit.lower().startswith("week"):
+        return value * 7
+    return value
+
 def validate_timeframe(date_str, cutoff_date):
     """
     Validates if a date is within the specified timeframe

--- a/utils/ui_components.py
+++ b/utils/ui_components.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from utils.common import calculate_lookback_days
 
 
 def _close_settings_param_check():
@@ -108,16 +109,23 @@ def render_settings_drawer():
                     "Time Period",
                     min_value=1,
                     step=1,
+                    value=st.session_state.get("time_value", 1),
                     key="time_value",
                 )
             with col2:
                 unit_options = ["Days", "Weeks"]
                 default_index = unit_options.index(st.session_state.get("time_unit", "Weeks"))
-                st.session_state.time_unit = st.selectbox(
+                st.selectbox(
                     "Unit",
                     unit_options,
                     index=default_index,
+                    key="time_unit",
                 )
+
+            st.session_state.lookback_days = calculate_lookback_days(
+                st.session_state.time_value,
+                st.session_state.time_unit,
+            )
 
             fetch_button = st.button(
                 "Fetch New Articles",


### PR DESCRIPTION
## Summary
- centralize lookback period conversion in `calculate_lookback_days`
- update UI drawer to compute `lookback_days`
- use `lookback_days` across main workflow and orchestrator
- simplify search agent timeframe logic
- fix session state errors when adjusting time inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6842d9243980832c9f7445542affc7ef